### PR TITLE
Update Greentea Git submodule to http

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tools/greentea-client"]
 	path = tools/greentea-client
-	url = git@github.com:ARMmbed/greentea-client.git
+	url = https://github.com/ARMmbed/greentea-client


### PR DESCRIPTION
Change Greentea git submodule to use http instead of ssh, as it simplifies the getting started process