### PR TITLE
contributing: use signoff rather than signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,4 +30,4 @@ See the License for the specific language governing permissions and limitations 
 
 Each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](./DCO.txt).
 
-If you set your `user.name` and `user.email` as part of your git configuration, you can sign your commit automatically with `git commit -s`. You have to use your real name (i.e., pseudonyms or anonymous contributions cannot be made). This is because the DCO is a legally binding document.
+If you set your `user.name` and `user.email` as part of your git configuration, you can add a signoff to your commit automatically with `git commit -s`. You have to use your real name (i.e., pseudonyms or anonymous contributions cannot be made). This is because the DCO is a legally binding document.


### PR DESCRIPTION
Same wording as git commit help provides for -s. This clarifies it we do not require
signed commits (verified) rather than signoff line.

cc @ithinuel