### PR TITLE
Enabled Github Action for License Check

### DIFF
--- a/.github/license_config.yml
+++ b/.github/license_config.yml
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+license:
+  main: apache-2.0
+  report_missing: true
+  category: Permissive
+copyright:
+  check: true
+exclude:
+  extensions:
+    - md
+    - json
+  langs:
+    - HTML

--- a/.github/workflows/PR-License-check.yml
+++ b/.github/workflows/PR-License-check.yml
@@ -1,0 +1,48 @@
+# Copyright (c) 2021 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+name: PR-Check License Validation
+
+on: [pull_request]
+
+jobs:
+  scancode_job:
+    runs-on: ubuntu-latest
+    name: Scan code for licenses
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+
+    - name: Scan the code for License
+      id: scancode
+      uses: zephyrproject-rtos/action_scancode@v3
+      with:
+        directory-to-scan: 'scan/'
+
+    - name: Artifact Upload
+      uses: actions/upload-artifact@v1
+      with:
+        name: LicenseScan
+        path: ./artifacts
+
+    - name: Check Scan Reports
+      run: |
+        if [ -s ./artifacts/report.txt ]; then
+          report=$(cat ./artifacts/report.txt)
+          report="${report//'%'/'%25'}"
+          report="${report//$'\n'/'%0A'}"
+          report="${report//$'\r'/'%0D'}"
+          echo "::error file=./artifacts/report.txt::$report"
+          exit 1
+        fi


### PR DESCRIPTION
Enabled Github Action for License Check Based on ADR Default Open source License

- Apache License 2.0 is the default license
- other permissive license types "BSD" or "MIT" also will be allowed
- The missing license will be reported
- other types of licenses will be reported

This is enabled by zephyr project scancode action tool