### PR TITLE
Flash API: Cleanup flash API and enable Greentea test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ add_subdirectory(tools/fpga_ci_test_shield)
 # HAL tests
 add_subdirectory(tests/mbed_hal/crc EXCLUDE_FROM_ALL)
 add_subdirectory(tests/mbed_hal/echo EXCLUDE_FROM_ALL)
+add_subdirectory(tests/mbed_hal/flash/functional_tests EXCLUDE_FROM_ALL)
 add_subdirectory(tests/mbed_hal/lp_ticker EXCLUDE_FROM_ALL)
 add_subdirectory(tests/mbed_hal/trng EXCLUDE_FROM_ALL)
 add_subdirectory(tests/mbed_hal/us_ticker EXCLUDE_FROM_ALL)

--- a/docs/porting/api/flash.md
+++ b/docs/porting/api/flash.md
@@ -100,8 +100,6 @@ uint32_t flash_get_start_address(const flash_t *obj);
 uint32_t flash_get_size(const flash_t *obj);
 ```
 
-To enable flash HAL, ensure the C macro `DEVICE_FLASH=1` is defined in the CMake variable `MBED_TARGET_DEFINITIONS`.
-
 ## Tests
 
 The tests for the `FlashIAP` flash HAL is available at `tests/mbed_hal/flash`.

--- a/hal/include/hal/flash_api.h
+++ b/hal/include/hal/flash_api.h
@@ -23,8 +23,6 @@
 #include "device.h"
 #include <stdint.h>
 
-#if DEVICE_FLASH
-
 #define MBED_FLASH_INVALID_SIZE     0xFFFFFFFF
 
 typedef struct flash_s flash_t;
@@ -125,8 +123,6 @@ uint8_t flash_get_erase_value(const flash_t *obj);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif
 
 #endif

--- a/hal/source/mbed_flash_api.c
+++ b/hal/source/mbed_flash_api.c
@@ -16,8 +16,6 @@
 
 #include "hal/flash_api.h"
 
-#if DEVICE_FLASH
-
 #include "bootstrap/mbed_toolchain.h"
 #include <string.h>
 
@@ -26,5 +24,3 @@ MBED_WEAK int32_t flash_read(flash_t *obj, uint32_t address, uint8_t *data, uint
     memcpy(data, (const void *)address, size);
     return 0;
 }
-
-#endif

--- a/tests/mbed_hal/flash/functional_tests/CMakeLists.txt
+++ b/tests/mbed_hal/flash/functional_tests/CMakeLists.txt
@@ -13,13 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+add_library(sdfx-test-flash-functional_tests OBJECT)
 
-set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../.. CACHE INTERNAL "")
-set(TEST_TARGET mbed-hal-flash-functional-tests)
+target_sources(sdfx-test-flash-functional_tests
+    PRIVATE
+        main.cpp
+)
 
-include(${MBED_PATH}/tools/cmake/mbed_greentea.cmake)
-
-project(${TEST_TARGET})
-
-mbed_greentea_add_test(TEST_NAME ${TEST_TARGET})
+target_link_libraries(sdfx-test-flash-functional_tests
+    PRIVATE
+        mbed-os
+        greentea::client
+        test-harness
+)


### PR DESCRIPTION
### Description <!-- Required -->
* Fix build errors for the flash functional tests for Greentea by removing dependencies on Mbed OS functionalities
* Expose the flash functional tests for Greentea as a CMake library
* Remove requirement to add the `DEVICE_FLASH` C macro to enable the flash API (It was a requirement for Mbed OS build issues)

<!--
Please provide the following information:
 
Description of the the change (what is this fixing / adding / removing).
-->
 
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test coverage <!-- Required -->
 
<!--
Provide all the information required, listing all the testing performed.
-->
[x] Manual testing (and evidence provided)
[] No additional tests required for this change (e.g documentation update)
